### PR TITLE
fix: add individual data save

### DIFF
--- a/src/gen_graph.py
+++ b/src/gen_graph.py
@@ -176,8 +176,6 @@ def save_set_graph(inst: dict, config: dict):
     else:
         ax = gen_single_graph(data, ax, inst, config)
 
-    # TODO: Individualグラフの保存
-
     ax = set_ax_inst(ax, inst)
     save_graphs(fig, inst['output_name'], dpi)
 
@@ -188,6 +186,15 @@ def save_set_graph(inst: dict, config: dict):
         save_describe(data, inst)
 
     plt.close()
+
+    # 個別のデータをプロットしたグラフを保存
+    if config["save_individual"] and inst["is_time_series"]:
+        fig, ax = plt.subplots()
+        fig.set_size_inches(figure_width, figure_height)
+        ax = gen_time_series_individual_graph(data, ax, inst)
+        ax = set_ax_inst(ax, inst)
+        save_graphs(fig, inst['output_name'] + "_individual", dpi)
+        plt.close()
 
 def save_graphs(fig: plt.Figure, output_name: str, dpi: int):
     out_path = os.path.join(OUTPUT_DIR, output_name)


### PR DESCRIPTION
This commit refactors the graph saving logic in the `save_set_graph` function. It removes the commented out code for saving individual graphs and instead adds a new section to save individual data plots. If the `save_individual` flag is set to true and the data is time series, it generates a separate graph for each individual data and saves it with the original output name appended with "_individual". This improves the organization and clarity of the code.

Co-authored-by: sakashita44